### PR TITLE
Fix discord watermark font

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -5,7 +5,7 @@
   font-family: 'Discord';
   font-weight: 900;
   font-style: normal;
-  src: url("https://raw.githubusercontent.com/powercord-org/powercord-backend/my-awesome-branch/web/src/assets/discord-font.otf") format("opentype");
+  src: url("https://raw.githubusercontent.com/powercord-org/powercord-backend/my-awesome-branch/packages/web/src/assets/discord-font.otf") format("opentype");
 }
 .theme-dark, 
 .theme-light, 

--- a/custom.css
+++ b/custom.css
@@ -5,7 +5,7 @@
   font-family: 'Discord';
   font-weight: 900;
   font-style: normal;
-  src: url("https://raw.githubusercontent.com/powercord-org/powercord-backend/my-awesome-branch/packages/web/src/assets/discord-font.otf") format("opentype");
+  src: url("https://github.com/powercord-org/powercord-backend/raw/b7525e457f932171197b4a97e2e4cd9c741e69fb/packages/web/src/assets/discord-font.otf") format("opentype");
 }
 .theme-dark, 
 .theme-light, 

--- a/custom.css
+++ b/custom.css
@@ -1,7 +1,12 @@
 
 @import url("https://raw.githack.com/LuckFire/CSS-Snippets/master/MoreRoundedBorders/borders.css");
-@import url("https://aokiare.github.io/addons/DiscordFont.css");
-@import url(https://raw.githack.com/moebamba/neptune/main/source.css);
+@import url("https://raw.githack.com/moebamba/neptune/main/source.css");
+@font-face {
+  font-family: 'Discord';
+  font-weight: 900;
+  font-style: normal;
+  src: url("https://raw.githubusercontent.com/powercord-org/powercord-backend/my-awesome-branch/web/src/assets/discord-font.otf") format("opentype");
+}
 .theme-dark, 
 .theme-light, 
 :root {


### PR DESCRIPTION
Removed the `@import` and defined a `@font-face` for the discord font with a `src` from powercord's github repo